### PR TITLE
Fix testAllMethods 

### DIFF
--- a/.squot
+++ b/.squot
@@ -1,5 +1,5 @@
 OrderedDictionary {
-	'packages\/PoppyPrint-Core.package' : #SquotCypressCodeSerializer,
-	'packages\/PoppyPrint-Tests.package' : #SquotCypressCodeSerializer,
-	'packages\/BaselineOfPoppyPrint.package' : #SquotCypressCodeSerializer
+	'packages/PoppyPrint-Core.package' : #SquotCypressCodeSerializer,
+	'packages/PoppyPrint-Tests.package' : #SquotCypressCodeSerializer,
+	'packages/BaselineOfPoppyPrint.package' : #SquotCypressCodeSerializer
 }

--- a/packages/PoppyPrint-Tests.package/PPFormatterTest.class/instance/testAllMethods.st
+++ b/packages/PoppyPrint-Tests.package/PPFormatterTest.class/instance/testAllMethods.st
@@ -1,6 +1,6 @@
 tests - examples
 testAllMethods
-	<timeout: 30 "seconds">
+	<timeout: 60 "seconds">
 
 	| methods results |
 	methods := self systemNavigation allClasses gather: [:class | class methodDictionary values, class theMetaClass methodDictionary values].

--- a/packages/PoppyPrint-Tests.package/PPFormatterTest.class/methodProperties.json
+++ b/packages/PoppyPrint-Tests.package/PPFormatterTest.class/methodProperties.json
@@ -8,7 +8,7 @@
 		"canFormatMethod:" : "ct 4/7/2021 15:51",
 		"exampleExplorerContents" : "tobe 3/11/2021 10:20",
 		"exampleMorphDoLayoutIn" : "tobe 3/11/2021 09:00",
-		"testAllMethods" : "ct 4/8/2021 12:26",
+		"testAllMethods" : "KD 5/7/2022 10:23",
 		"testBinaryMessageChain" : "tobe 3/11/2021 10:58",
 		"testBinaryMessageChainWithParenthesis" : "tobe 3/11/2021 13:33",
 		"testCommentAtStartOfBlock" : "tobe 3/11/2021 10:08",


### PR DESCRIPTION
testAllMethods seemed very flaky. Timeout is increased to 60s so it should be enough time to complete the test always. At least at this point in development.