### PR TITLE
Fix timeout in testAllMethods

### DIFF
--- a/packages/PoppyPrint-Tests.package/PPFormatterTest.class/instance/testAllMethods.st
+++ b/packages/PoppyPrint-Tests.package/PPFormatterTest.class/instance/testAllMethods.st
@@ -1,6 +1,6 @@
 tests - examples
 testAllMethods
-	<timeout: 60 "seconds">
+	<timeout: 120 "seconds">
 
 	| methods results |
 	methods := self systemNavigation allClasses gather: [:class | class methodDictionary values, class theMetaClass methodDictionary values].

--- a/packages/PoppyPrint-Tests.package/PPFormatterTest.class/methodProperties.json
+++ b/packages/PoppyPrint-Tests.package/PPFormatterTest.class/methodProperties.json
@@ -8,7 +8,7 @@
 		"canFormatMethod:" : "ct 4/7/2021 15:51",
 		"exampleExplorerContents" : "tobe 3/11/2021 10:20",
 		"exampleMorphDoLayoutIn" : "tobe 3/11/2021 09:00",
-		"testAllMethods" : "KD 5/7/2022 10:23",
+		"testAllMethods" : "KD 5/11/2022 18:29",
 		"testBinaryMessageChain" : "tobe 3/11/2021 10:58",
 		"testBinaryMessageChainWithParenthesis" : "tobe 3/11/2021 13:33",
 		"testCommentAtStartOfBlock" : "tobe 3/11/2021 10:08",


### PR DESCRIPTION
As mentioned in reopening the issue an increase to 120s timeout seems more appropriate.

Closes #48 
